### PR TITLE
Dn alternate

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ There are other orthographic features:
 
 - `MS_SUFX` — HEBREW LETTER QAMATS (U+05B8) and YOD (U+05D9) and VAV (U+05D5) יו◌ָ
 - `DIVINE_NAME` — the full form of the divine name - יהוה
+- `DIVINE_NAME_ELOHIM` — optionally, the form of the divine name pointed as ʾelōhîm (e.g. יֱהֹוִה)
 - `SYLLABLE_SEPARATOR` — a syllable separator, usually an empty string
 - `DAGESH_CHAZAQ` — if true, repeats the consonant with the _dagesh_
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -301,7 +301,10 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
 const getDivineName = (str: string, schema: Schema): string => {
   const begn = str[0];
   const end = str[str.length - 1];
-  return `${hebChars.test(begn) ? "" : begn}${schema.DIVINE_NAME}${hebChars.test(end) ? "" : end}`;
+  // if DN is pointed with a hiriq, then it is read as 'elohim
+  const divineName =
+    schema.DIVINE_NAME_ELOHIM && /\u{05B4}/u.test(str) ? schema.DIVINE_NAME_ELOHIM : schema.DIVINE_NAME;
+  return `${hebChars.test(begn) ? "" : begn}${divineName}${hebChars.test(end) ? "" : end}`;
 };
 
 export const wordRules = (word: Word, schema: Schema): string | Word => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -636,6 +636,22 @@ export class Schema implements SylOpts, SchemaVowels {
    */
   DIVINE_NAME: string;
   /**
+   * the full form of the divine name pointed as 'elohim
+   *
+   * @description
+   * matched on the forms:
+   * - יֱהֹוִה
+   * - יֱהוִה
+   * - יְהֹוִה
+   * - יְהוִה
+   *
+   * If undefined, defaults to `DIVINE_NAME`
+   *
+   * @example
+   * 'ʾelōhim'
+   */
+  DIVINE_NAME_ELOHIM?: string;
+  /**
    * a syllable separator, usually an empty string
    *  @example
    * '' or '-'
@@ -735,6 +751,7 @@ export class Schema implements SylOpts, SchemaVowels {
       (this.TAV = schema.TAV),
       (this.TAV_DAGESH = schema.TAV_DAGESH),
       (this.DIVINE_NAME = schema.DIVINE_NAME),
+      (this.DIVINE_NAME_ELOHIM = schema.DIVINE_NAME_ELOHIM),
       (this.SYLLABLE_SEPARATOR = schema.SYLLABLE_SEPARATOR),
       (this.ADDITIONAL_FEATURES = schema.ADDITIONAL_FEATURES),
       (this.STRESS_MARKER = schema.STRESS_MARKER),
@@ -744,8 +761,8 @@ export class Schema implements SylOpts, SchemaVowels {
       (this.wawShureq = schema.wawShureq),
       (this.article = schema.article),
       (this.allowNoNiqqud = schema.allowNoNiqqud),
-      (this.strict = schema.strict);
-    this.holemHaser = schema.holemHaser;
+      (this.strict = schema.strict),
+      (this.holemHaser = schema.holemHaser);
   }
 }
 
@@ -815,6 +832,7 @@ export class SBL extends Schema {
       TAV: schema.TAV ?? "t",
       TAV_DAGESH: schema.TAV_DAGESH ?? undefined,
       DIVINE_NAME: schema.DIVINE_NAME ?? "yhwh",
+      DIVINE_NAME_ELOHIM: schema.DIVINE_NAME_ELOHIM ?? undefined,
       SYLLABLE_SEPARATOR: schema.SYLLABLE_SEPARATOR ?? undefined,
       ADDITIONAL_FEATURES: schema.ADDITIONAL_FEATURES ?? undefined,
       STRESS_MARKER: schema.STRESS_MARKER ?? undefined,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -639,7 +639,7 @@ export class Schema implements SylOpts, SchemaVowels {
    * the full form of the divine name pointed as 'elohim
    *
    * @description
-   * matched on the forms:
+   * matches on the forms:
    * - יֱהֹוִה
    * - יֱהוִה
    * - יְהֹוִה

--- a/test/transliterate.test.ts
+++ b/test/transliterate.test.ts
@@ -144,6 +144,20 @@ describe("using default options", () => {
     });
   });
 
+  describe("divine name, elohim", () => {
+    test.each`
+      description           | hebrew        | transliteration | options
+      ${"full pointing"}    | ${"יֱהֹוִ֡ה"} | ${"ʾelōhim"}    | ${{ DIVINE_NAME_ELOHIM: "ʾelōhim" }}
+      ${"with segol"}       | ${"יֱהוִה"}   | ${"ʾelōhim"}    | ${{ DIVINE_NAME_ELOHIM: "ʾelōhim" }}
+      ${"with holam"}       | ${"יְהֹוִה"}  | ${"ʾelōhim"}    | ${{ DIVINE_NAME_ELOHIM: "ʾelōhim" }}
+      ${"with hiriq"}       | ${"יְהוִֽה׃"} | ${"ʾelōhim"}    | ${{ DIVINE_NAME_ELOHIM: "ʾelōhim" }}
+      ${"undefined option"} | ${"יֱהֹוִ֡ה"} | ${"yhwh"}       | ${{ DIVINE_NAME_ELOHIM: undefined }}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration, options } = inputs;
+      expect(transliterate(hebrew, options)).toBe(transliteration);
+    });
+  });
+
   describe("qamets qatan", () => {
     test.each`
       description            | hebrew           | transliteration


### PR DESCRIPTION
Closes #40 

Adds a new property to the schema

```ts
/**
 * the full form of the divine name pointed as 'elohim
 *
 * @description
 * matched on the forms:
 * - יֱהֹוִה
 * - יֱהוִה
 * - יְהֹוִה
 * - יְהוִה
 *
 * If undefined, defaults to `DIVINE_NAME`
 *
 * @example
 * 'ʾelōhim'
 */
DIVINE_NAME_ELOHIM?: string;
```

Usage:

```js
heb.transliterate("אֲנִ֖י אֲדֹנָ֥י יְהוִֽה׃", { DIVINE_NAME_ELOHIM: "ʾelōhîm" });
// ʾănî ʾădōnāy ʾelōhîm
```