### PR TITLE
Pass through option

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ heb.transliterate("הַזֹּאת", {
 - In the Romaniote reading tradition, however, the `ZAYIN` is usually transliterated with `'z'` (really `'ζ'`),
 - but a `ZAYIN` followed by a _dagesh_ is transliterated as `'tz'` (really `'τζ'`)
 
-Each additional feature consists of 3 parts:
+Each additional feature consists of 4 properties:
 
 1. `FEATURE` — has three options:
   - `"cluster"` — a `cluster` is any combination of a single character and optionally a *dagesh* and vowel.
@@ -303,6 +303,7 @@ Each additional feature consists of 3 parts:
   - `"word"` — covers everything else
 2. `HEBREW` — the Hebrew text to be transliterated
 3. `TRANSLITERATION` — the text used to transliterate the Hebrew text, or a callback function
+4. `PASS_THROUGH` — if `true` passes the characters of the result of the `TRANSLITERATION` callback to the be mapped to the schema. If `TRANSLITERATION` is a string, this does nothing. Default `true`.
 
 **Using a callback**
 
@@ -326,8 +327,7 @@ heb.transliterate("בְּרֵאשִׁ֖ית וַיַּבְדֵּל", {
 
         if (next && nextVowel) {
           const vowel = schema[nextVowel] || "";
-          // replaceAndTransliterate is an internal helper function
-          return rules.replaceAndTransliterate(syllable.text, new RegExp("\u{05B0}", "u"), vowel, schema);
+          return syllable.text.replace(new RegExp("\u{05B0}", "u"), vowel);
         }
 
         return syllable.text;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "scripts": {
     "build": "tsc",
     "test": "clear && jest",
+    "test:transliterate": "clear && jest test/transliterate.test.ts",
+    "test:remove": "clear && jest test/remove.test.ts",
+    "test:sequence": "clear && jest test/sequence.test.ts",
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts'",
     "lint": "eslint . --ext .ts",
     "prepare": "npm run build",

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -5,6 +5,8 @@ import { hebChars } from "havarotjs/dist/utils/regularExpressions";
 import { Schema } from "./schema";
 import { transliterateMap as map } from "./hebCharsTrans";
 
+const taamim = /[\u{0590}-\u{05AF}\u{05BD}\u{05BF}]/u;
+
 /**
  * maps Hebrew characters to schema
  *
@@ -15,8 +17,6 @@ import { transliterateMap as map } from "./hebCharsTrans";
  */
 export const mapChars = (input: string, schema: Schema) =>
   [...input].map((char: string) => (char in map ? schema[map[char]] : char)).join("");
-
-const taamim = /[\u{0590}-\u{05AF}\u{05BD}\u{05BF}]/u;
 
 /**
  * a wrapper around String.replace() to constrain to a RegExp
@@ -60,6 +60,141 @@ const getDageshChazaqVal = (input: string, dagesh: Schema["DAGESH_CHAZAQ"], isCh
   }
 
   return input + dagesh;
+};
+
+/**
+ * formats the Divine Name with any Latin chars
+ *
+ * @param str word text
+ * @param schema
+ * @returns the Divine Name with any pre or proceding Latin chars
+ */
+const getDivineName = (str: string, schema: Schema): string => {
+  const begn = str[0];
+  const end = str[str.length - 1];
+  // if DN is pointed with a hiriq, then it is read as 'elohim
+  const divineName =
+    schema.DIVINE_NAME_ELOHIM && /\u{05B4}/u.test(str) ? schema.DIVINE_NAME_ELOHIM : schema.DIVINE_NAME;
+  return `${hebChars.test(begn) ? "" : begn}${divineName}${hebChars.test(end) ? "" : end}`;
+};
+
+const materFeatures = (syl: Syllable, schema: Schema) => {
+  const mater = syl.clusters.filter((c) => c.isMater)[0];
+  const prev = mater.prev instanceof Cluster ? mater.prev : null;
+  const materText = mater.text;
+  const prevText = (prev?.text || "").replace(taamim, "");
+  // string comprised of all non-mater clusters in a syl with a mater
+  let noMaterText = syl.clusters
+    .filter((c) => !c.isMater)
+    .map((c) => consonantFeatures(c.text.replace(taamim, ""), syl, c, schema))
+    .join("");
+
+  // workaround for maqaf
+  const hasMaqaf = mater.text.includes("־");
+  noMaterText = hasMaqaf ? noMaterText.concat("־") : noMaterText;
+
+  if (/י/.test(materText)) {
+    // hiriq
+    if (/\u{05B4}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B4}/u, schema.HIRIQ_YOD);
+    }
+    // tsere
+    if (/\u{05B5}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B5}/u, schema.TSERE_YOD);
+    }
+    // segol
+    if (/\u{05B6}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B6}/u, schema.SEGOL_YOD);
+    }
+  }
+
+  if (/ו/u.test(materText)) {
+    // holam
+    if (/\u{05B9}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B9}/u, schema.HOLAM_VAV);
+    }
+  }
+
+  if (/ה/.test(materText)) {
+    // qamets
+    if (/\u{05B8}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B8}/u, schema.QAMATS_HE);
+    }
+
+    // seghol
+    if (/\u{05B6}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B6}/u, schema.SEGOL_HE);
+    }
+
+    // tsere
+    if (/\u{05B5}/u.test(prevText)) {
+      return replaceWithRegex(noMaterText, /\u{05B5}/u, schema.SEGOL_HE);
+    }
+  }
+
+  return materText;
+};
+
+const joinSyllableChars = (syl: Syllable, sylChars: string[], schema: Schema): string => {
+  if (!syl.isAccented) {
+    return sylChars.map((char) => mapChars(char, schema)).join("");
+  }
+
+  if (schema.STRESS_MARKER) {
+    const exclude = schema.STRESS_MARKER?.exclude ?? "never";
+
+    if (exclude === "single" && !syl.prev && !syl.next) {
+      return sylChars.map((char) => mapChars(char, schema)).join("");
+    }
+
+    if (exclude === "final" && !syl.next) {
+      return sylChars.map((char) => mapChars(char, schema)).join("");
+    }
+
+    const location = schema.STRESS_MARKER.location;
+    const mark = schema.STRESS_MARKER.mark;
+    if (location === "before-syllable") {
+      return `${mark}${sylChars.map((char) => mapChars(char, schema)).join("")}`;
+    }
+
+    if (location === "after-syllable") {
+      return `${sylChars.map((char) => mapChars(char, schema)).join("")}${mark}`;
+    }
+
+    const vowels = [
+      schema.PATAH,
+      schema.HATAF_PATAH,
+      schema.QAMATS,
+      schema.HATAF_QAMATS,
+      schema.SEGOL,
+      schema.HATAF_SEGOL,
+      schema.TSERE,
+      schema.HIRIQ,
+      schema.HOLAM,
+      schema.QAMATS_QATAN,
+      schema.QUBUTS,
+      schema.QAMATS_HE,
+      schema.SEGOL_HE,
+      schema.TSERE_HE,
+      schema.HIRIQ_YOD,
+      schema.TSERE_YOD,
+      schema.SEGOL_YOD,
+      schema.HOLAM_VAV,
+      schema.SHUREQ
+    ].sort((a, b) => b.length - a.length);
+    const vowelRgx = new RegExp(`${vowels.join("|")}`);
+    const str = sylChars.map((char) => mapChars(char, schema)).join("");
+    const match = str.match(vowelRgx);
+
+    if (location === "before-vowel") {
+      return match?.length ? str.replace(match[0], `${mark}${match[0]}`) : str;
+    }
+
+    // after-vowel
+    return match?.length ? str.replace(match[0], `${match[0]}${mark}`) : str;
+  }
+
+  return sylChars.map((char) => mapChars(char, schema)).join("");
 };
 
 const consonantFeatures = (clusterText: string, syl: Syllable, cluster: Cluster, schema: Schema) => {
@@ -195,125 +330,6 @@ const consonantFeatures = (clusterText: string, syl: Syllable, cluster: Cluster,
   return clusterText;
 };
 
-const materFeatures = (syl: Syllable, schema: Schema) => {
-  const mater = syl.clusters.filter((c) => c.isMater)[0];
-  const prev = mater.prev instanceof Cluster ? mater.prev : null;
-  const materText = mater.text;
-  const prevText = (prev?.text || "").replace(taamim, "");
-  // string comprised of all non-mater clusters in a syl with a mater
-  let noMaterText = syl.clusters
-    .filter((c) => !c.isMater)
-    .map((c) => consonantFeatures(c.text.replace(taamim, ""), syl, c, schema))
-    .join("");
-
-  // workaround for maqaf
-  const hasMaqaf = mater.text.includes("־");
-  noMaterText = hasMaqaf ? noMaterText.concat("־") : noMaterText;
-
-  if (/י/.test(materText)) {
-    // hiriq
-    if (/\u{05B4}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B4}/u, schema.HIRIQ_YOD);
-    }
-    // tsere
-    if (/\u{05B5}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B5}/u, schema.TSERE_YOD);
-    }
-    // segol
-    if (/\u{05B6}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B6}/u, schema.SEGOL_YOD);
-    }
-  }
-
-  if (/ו/u.test(materText)) {
-    // holam
-    if (/\u{05B9}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B9}/u, schema.HOLAM_VAV);
-    }
-  }
-
-  if (/ה/.test(materText)) {
-    // qamets
-    if (/\u{05B8}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B8}/u, schema.QAMATS_HE);
-    }
-
-    // seghol
-    if (/\u{05B6}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B6}/u, schema.SEGOL_HE);
-    }
-
-    // tsere
-    if (/\u{05B5}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B5}/u, schema.SEGOL_HE);
-    }
-  }
-
-  return materText;
-};
-
-const joinChars = (syl: Syllable, sylChars: string[], schema: Schema): string => {
-  if (!syl.isAccented) {
-    return sylChars.map((char) => mapChars(char, schema)).join("");
-  }
-
-  if (schema.STRESS_MARKER) {
-    const exclude = schema.STRESS_MARKER?.exclude ?? "never";
-
-    if (exclude === "single" && !syl.prev && !syl.next) {
-      return sylChars.map((char) => mapChars(char, schema)).join("");
-    }
-
-    if (exclude === "final" && !syl.next) {
-      return sylChars.map((char) => mapChars(char, schema)).join("");
-    }
-
-    const location = schema.STRESS_MARKER.location;
-    const mark = schema.STRESS_MARKER.mark;
-    if (location === "before-syllable") {
-      return `${mark}${sylChars.map((char) => mapChars(char, schema)).join("")}`;
-    }
-
-    if (location === "after-syllable") {
-      return `${sylChars.map((char) => mapChars(char, schema)).join("")}${mark}`;
-    }
-
-    const vowels = [
-      schema.PATAH,
-      schema.HATAF_PATAH,
-      schema.QAMATS,
-      schema.HATAF_QAMATS,
-      schema.SEGOL,
-      schema.HATAF_SEGOL,
-      schema.TSERE,
-      schema.HIRIQ,
-      schema.HOLAM,
-      schema.QAMATS_QATAN,
-      schema.QUBUTS,
-      schema.QAMATS_HE,
-      schema.SEGOL_HE,
-      schema.TSERE_HE,
-      schema.HIRIQ_YOD,
-      schema.TSERE_YOD,
-      schema.SEGOL_YOD,
-      schema.HOLAM_VAV,
-      schema.SHUREQ
-    ].sort((a, b) => b.length - a.length);
-    const vowelRgx = new RegExp(`${vowels.join("|")}`);
-    const str = sylChars.map((char) => mapChars(char, schema)).join("");
-    const match = str.match(vowelRgx);
-
-    if (location === "before-vowel") {
-      return match?.length ? str.replace(match[0], `${mark}${match[0]}`) : str;
-    }
-
-    // after-vowel
-    return match?.length ? str.replace(match[0], `${match[0]}${mark}`) : str;
-  }
-
-  return sylChars.map((char) => mapChars(char, schema)).join("");
-};
-
 export const sylRules = (syl: Syllable, schema: Schema): string => {
   const sylTxt = syl.text.replace(taamim, "");
 
@@ -344,14 +360,14 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
   const mSSuffix = /\u{05B8}\u{05D9}\u{05D5}/u;
   if (syl.isFinal && mSSuffix.test(sylTxt)) {
     const sufxSyl = replaceWithRegex(sylTxt, mSSuffix, schema.MS_SUFX);
-    return joinChars(syl, [...sufxSyl], schema);
+    return joinSyllableChars(syl, [...sufxSyl], schema);
   }
 
   // syllable has a mater
   const hasMater = syl.clusters.map((c) => c.isMater).includes(true);
   if (hasMater) {
     const materSyl = materFeatures(syl, schema);
-    return joinChars(syl, [...materSyl], schema);
+    return joinSyllableChars(syl, [...materSyl], schema);
   }
 
   // regular syllables
@@ -360,23 +376,7 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
     return consonantFeatures(clusterText, syl, cluster, schema);
   });
 
-  return joinChars(syl, returnTxt, schema);
-};
-
-/**
- * formats the Divine Name with any Latin chars
- *
- * @param str word text
- * @param schema
- * @returns the Divine Name with any pre or proceding Latin chars
- */
-const getDivineName = (str: string, schema: Schema): string => {
-  const begn = str[0];
-  const end = str[str.length - 1];
-  // if DN is pointed with a hiriq, then it is read as 'elohim
-  const divineName =
-    schema.DIVINE_NAME_ELOHIM && /\u{05B4}/u.test(str) ? schema.DIVINE_NAME_ELOHIM : schema.DIVINE_NAME;
-  return `${hebChars.test(begn) ? "" : begn}${divineName}${hebChars.test(end) ? "" : end}`;
+  return joinSyllableChars(syl, returnTxt, schema);
 };
 
 export const wordRules = (word: Word, schema: Schema): string | Word => {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -69,8 +69,11 @@ const consonantFeatures = (clusterText: string, syl: Syllable, cluster: Cluster,
       const heb = new RegExp(seq.HEBREW, "u");
       if (seq.FEATURE === "cluster" && heb.test(clusterText)) {
         const transliteration = seq.TRANSLITERATION;
+        const passThrough = seq.PASS_THROUGH ?? true;
         return typeof transliteration === "string"
           ? replaceAndTransliterate(clusterText, heb, transliteration, schema)
+          : passThrough
+          ? mapChars(transliteration(cluster, seq.HEBREW, schema), schema)
           : transliteration(cluster, seq.HEBREW, schema);
       }
     }
@@ -318,8 +321,11 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
       const heb = new RegExp(seq.HEBREW, "u");
       if (seq.FEATURE === "syllable" && heb.test(sylTxt)) {
         const transliteration = seq.TRANSLITERATION;
+        const passThrough = seq.PASS_THROUGH ?? true;
         return typeof transliteration === "string"
           ? replaceAndTransliterate(sylTxt, heb, transliteration, schema)
+          : passThrough
+          ? mapChars(transliteration(syl, seq.HEBREW, schema), schema)
           : transliteration(syl, seq.HEBREW, schema);
       }
     }
@@ -377,8 +383,11 @@ export const wordRules = (word: Word, schema: Schema): string | Word => {
       const text = word.text.replace(taamim, "");
       if (seq.FEATURE === "word" && heb.test(text)) {
         const transliteration = seq.TRANSLITERATION;
+        const passThrough = seq.PASS_THROUGH ?? true;
         return typeof transliteration === "string"
           ? replaceAndTransliterate(text, heb, transliteration, schema)
+          : passThrough
+          ? mapChars(transliteration(word, seq.HEBREW, schema), schema)
           : transliteration(word, seq.HEBREW, schema);
       }
     }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -15,8 +15,9 @@ const taamim = /[\u{0590}-\u{05AF}\u{05BD}\u{05BF}]/u;
  * @returns transliteration of characters
  *
  */
-export const mapChars = (input: string, schema: Schema) =>
-  [...input].map((char: string) => (char in map ? schema[map[char]] : char)).join("");
+export const mapChars = (schema: Schema) => (input: string) => {
+  return [...input].map((char: string) => (char in map ? schema[map[char]] : char)).join("");
+};
 
 /**
  * a wrapper around String.replace() to constrain to a RegExp
@@ -47,7 +48,7 @@ const replaceWithRegex = (input: string, regex: RegExp, replaceValue: string) =>
  */
 export const replaceAndTransliterate = (input: string, regex: RegExp, replaceValue: string, schema: Schema) => {
   const sylSeq = replaceWithRegex(input, regex, replaceValue);
-  return [...sylSeq].map((char) => mapChars(char, schema)).join("");
+  return [...sylSeq].map(mapChars(schema)).join("");
 };
 
 const getDageshChazaqVal = (input: string, dagesh: Schema["DAGESH_CHAZAQ"], isChazaq: boolean) => {
@@ -137,28 +138,28 @@ const materFeatures = (syl: Syllable, schema: Schema) => {
 
 const joinSyllableChars = (syl: Syllable, sylChars: string[], schema: Schema): string => {
   if (!syl.isAccented) {
-    return sylChars.map((char) => mapChars(char, schema)).join("");
+    return sylChars.map(mapChars(schema)).join("");
   }
 
   if (schema.STRESS_MARKER) {
     const exclude = schema.STRESS_MARKER?.exclude ?? "never";
 
     if (exclude === "single" && !syl.prev && !syl.next) {
-      return sylChars.map((char) => mapChars(char, schema)).join("");
+      return sylChars.map(mapChars(schema)).join("");
     }
 
     if (exclude === "final" && !syl.next) {
-      return sylChars.map((char) => mapChars(char, schema)).join("");
+      return sylChars.map(mapChars(schema)).join("");
     }
 
     const location = schema.STRESS_MARKER.location;
     const mark = schema.STRESS_MARKER.mark;
     if (location === "before-syllable") {
-      return `${mark}${sylChars.map((char) => mapChars(char, schema)).join("")}`;
+      return `${mark}${sylChars.map(mapChars(schema)).join("")}`;
     }
 
     if (location === "after-syllable") {
-      return `${sylChars.map((char) => mapChars(char, schema)).join("")}${mark}`;
+      return `${sylChars.map(mapChars(schema)).join("")}${mark}`;
     }
 
     const vowels = [
@@ -183,7 +184,7 @@ const joinSyllableChars = (syl: Syllable, sylChars: string[], schema: Schema): s
       schema.SHUREQ
     ].sort((a, b) => b.length - a.length);
     const vowelRgx = new RegExp(`${vowels.join("|")}`);
-    const str = sylChars.map((char) => mapChars(char, schema)).join("");
+    const str = sylChars.map(mapChars(schema)).join("");
     const match = str.match(vowelRgx);
 
     if (location === "before-vowel") {
@@ -194,7 +195,7 @@ const joinSyllableChars = (syl: Syllable, sylChars: string[], schema: Schema): s
     return match?.length ? str.replace(match[0], `${match[0]}${mark}`) : str;
   }
 
-  return sylChars.map((char) => mapChars(char, schema)).join("");
+  return sylChars.map(mapChars(schema)).join("");
 };
 
 const consonantFeatures = (clusterText: string, syl: Syllable, cluster: Cluster, schema: Schema) => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -16,10 +16,14 @@ interface HebrewFeature {
 
 interface PassThrough {
   /**
-   * if `true` passes the characters of the result of the `TRANSLITERATION` callback to the be mapped to the schema
+   * if `true` passes the characters of the result of the `TRANSLITERATION` callback to the be mapped to the schema.
+   * If `TRANSLITERATION` is a string, this does nothing.
    *
    * @default
    * true
+   *
+   * @description
+   * This is generally most useful when the callback does not transliterate the entire `FEATURE`
    *
    * @example
    *

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -14,6 +14,67 @@ interface HebrewFeature {
   HEBREW: string | RegExp;
 }
 
+interface PassThrough {
+  /**
+   * if `true` passes the characters of the result of the `TRANSLITERATION` callback to the be mapped to the schema
+   *
+   * @default
+   * true
+   *
+   * @example
+   *
+   * ```js
+   * // with PASS_THROUGH true (or undefined), the rest of the characters are passed through
+   * // to regular mapping on the schema
+   * heb.transliterate("בְּרֵאשִׁ֖ית", {
+   *   ADDITIONAL_FEATURES: [{
+   *     HEBREW: "(?<![\u{05B1}-\u{05BB}\u{05C7}].*)\u{05B0}",
+   *     FEATURE: "syllable",
+   *     PASS_THROUGH: true,
+   *     TRANSLITERATION: function (syllable, _hebrew, schema) {
+   *       const next = syllable.next;
+   *       const nextVowel = next.vowelName === "SHEVA" ? "VOCAL_SHEVA" : next.vowelName
+   *
+   *       if (next && nextVowel) {
+   *         const vowel = schema[nextVowel] || "";
+   *         return syllable.text.replace(new RegExp("\u{05B0}", "u"), vowel);
+   *       }
+   *
+   *       return syllable.text;
+   *     }
+   *   }]
+   * });
+   * ```
+   *
+   * @example
+   *
+   * ```js
+   * // with PASS_THROUGH false, a custom mapping needs to be implemented,
+   * // or Hebrew characters are returned for the rest of the `FEATURE`
+   * heb.transliterate("בְּרֵאשִׁ֖ית", {
+   *   ADDITIONAL_FEATURES: [{
+   *     HEBREW: "(?<![\u{05B1}-\u{05BB}\u{05C7}].*)\u{05B0}",
+   *     FEATURE: "syllable",
+   *     PASS_THROUGH: false,
+   *     TRANSLITERATION: function (syllable, _hebrew, schema) {
+   *       const next = syllable.next;
+   *       const nextVowel = next.vowelName === "SHEVA" ? "VOCAL_SHEVA" : next.vowelName
+   *
+   *       if (next && nextVowel) {
+   *         const vowel = schema[nextVowel] || "";
+   *         return syllable.text.replace(new RegExp("\u{05B0}", "u"), vowel);
+   *       }
+   *
+   *       return syllable.text;
+   *     }
+   *   }]
+   * });
+   * // בּērēʾšît
+   * ```
+   */
+  PASS_THROUGH?: boolean;
+}
+
 /**
  * @param word the `Word` object that matches the `HEBREW` property
  * @param hebrew the `HEBREW` property
@@ -21,7 +82,7 @@ interface HebrewFeature {
  */
 type WordCallback = (word: Word, hebrew: string | RegExp, schema: Schema) => string;
 
-interface WordFeature extends HebrewFeature {
+interface WordFeature extends HebrewFeature, PassThrough {
   /**
    * additional orthographic feature
    *
@@ -82,7 +143,7 @@ interface WordFeature extends HebrewFeature {
  */
 type SyllableCallback = (syllable: Syllable, hebrew: string | RegExp, schema: Schema) => string;
 
-interface SyllableFeature extends HebrewFeature {
+interface SyllableFeature extends HebrewFeature, PassThrough {
   /**
    * additional orthographic feature
    *
@@ -92,9 +153,6 @@ interface SyllableFeature extends HebrewFeature {
    */
   FEATURE: "syllable";
   /**
-   *
-   * DONT COMMIT W/O UPDATING EXAMPLES!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-   *
    * a string or callback
    *
    * Using a string
@@ -146,7 +204,7 @@ interface SyllableFeature extends HebrewFeature {
  */
 type ClusterCallback = (cluster: Cluster, hebrew: string | RegExp, schema: Schema) => string;
 
-interface ClusterFeature extends HebrewFeature {
+interface ClusterFeature extends HebrewFeature, PassThrough {
   /**
    * additional orthographic feature
    *

--- a/src/transliterate.ts
+++ b/src/transliterate.ts
@@ -71,7 +71,7 @@ export const transliterate = (text: string | Text, schema?: Partial<Schema> | Sc
     .map((word) => {
       let transliteration = wordRules(word, transSchema);
       if (transliteration instanceof Word) {
-        transliteration = word.syllables
+        transliteration = transliteration.syllables
           .map((s) => sylRules(s, transSchema))
           .join(transSchema.SYLLABLE_SEPARATOR ?? "");
       }

--- a/test/transliterate.test.ts
+++ b/test/transliterate.test.ts
@@ -1,7 +1,6 @@
 import { Cluster } from "havarotjs/cluster";
 import { Syllable } from "havarotjs/syllable";
 import { transliterate, Schema } from "../src/index";
-import { replaceAndTransliterate } from "../src/rules";
 
 interface Inputs {
   hebrew: string;
@@ -256,7 +255,7 @@ describe("extending SBL schema for optional arguments", () => {
                 const tsere = /\u{05B5}/u;
                 const next = cluster.next as Cluster;
                 if (next && tsere.test(next.text)) {
-                  return replaceAndTransliterate(cluster.text, new RegExp(hebrew, "u"), schema["TSERE"], schema);
+                  return cluster.text.replace(new RegExp(hebrew, "u"), schema["TSERE"]);
                 }
                 return cluster.text;
               }
@@ -282,7 +281,7 @@ describe("extending SBL schema for optional arguments", () => {
 
                 if (next && nextVowel) {
                   const vowel = schema[nextVowel] || "";
-                  return replaceAndTransliterate(syllable.text, /\u{05B0}/u, vowel, schema);
+                  return syllable.text.replace(/\u{05B0}/u, vowel);
                 }
 
                 return syllable.text;
@@ -307,7 +306,7 @@ describe("extending SBL schema for optional arguments", () => {
 
                 if (next && nextVowel) {
                   const vowel = schema[nextVowel] || "";
-                  return replaceAndTransliterate(syllable.text, /\u{05B0}/u, vowel, schema);
+                  return syllable.text.replace(/\u{05B0}/u, vowel);
                 }
 
                 return syllable.text;

--- a/test/transliterate.test.ts
+++ b/test/transliterate.test.ts
@@ -316,6 +316,32 @@ describe("extending SBL schema for optional arguments", () => {
         })
       ).toEqual("wayyabdēl");
     });
+
+    test("syllable callback with PASS_THROUGH false", () => {
+      const heb = "בְּרֵאשִׁ֖ית";
+      expect(
+        transliterate(heb, {
+          ADDITIONAL_FEATURES: [
+            {
+              HEBREW: "(?<![\u{05B1}-\u{05BB}\u{05C7}].*)\u{05B0}",
+              FEATURE: "syllable",
+              PASS_THROUGH: false,
+              TRANSLITERATION: function (syllable, _hebrew, schema) {
+                const next = syllable.next as Syllable;
+                const nextVowel = next.vowelName === "SHEVA" ? "VOCAL_SHEVA" : next.vowelName;
+
+                if (next && nextVowel) {
+                  const vowel = schema[nextVowel] || "";
+                  return syllable.text.replace(/\u{05B0}/u, vowel);
+                }
+
+                return syllable.text;
+              }
+            }
+          ]
+        })
+      ).toEqual("בּērēʾšît");
+    });
   });
 
   describe("additional feature with callback for a word", () => {

--- a/test/transliterate.test.ts
+++ b/test/transliterate.test.ts
@@ -368,6 +368,31 @@ describe("extending SBL schema for optional arguments", () => {
         })
       ).toEqual("štayim");
     });
+
+    test("word callback with PASS_THROUGH false (no effect)", () => {
+      const heb = "שְׁתַּיִם";
+      expect(
+        transliterate(heb, {
+          ADDITIONAL_FEATURES: [
+            {
+              HEBREW: "שְׁתַּיִם",
+              FEATURE: "word",
+              PASS_THROUGH: false,
+              TRANSLITERATION: function (_word, _hebrew, schema) {
+                return (
+                  schema["SHIN"] +
+                  (schema["TAV_DAGESH"] ?? schema["TAV"]) +
+                  schema["PATAH"] +
+                  schema["YOD"] +
+                  schema["HIRIQ"] +
+                  schema["FINAL_MEM"]
+                );
+              }
+            }
+          ]
+        })
+      ).toEqual("štayim");
+    });
   });
 
   describe("stress marks", () => {


### PR DESCRIPTION
Closes #53 

With `PASS_THROUGH` defaulted to `true` it gives a more predictable outcome

_I did notice that taamim can mess with it too_:

```js
// obviously, not how this word is ever inflected
const result = heb.transliterate("בְּרֵאשִׁ֖יתִי", {
  ADDITIONAL_FEATURES: [
    {
      HEBREW: "בְּרֵאשִׁית",
      FEATURE: "word",
      PASS_THROUGH: false,
      TRANSLITERATION: function (word, hebrew, schema) {
        return word.text.replace(new RegExp(hebrew), "beginning");
      }
    }
  ]
});

console.log(result);
// בְּרֵאשִׁ֖יתִי
```

Because the input has taamim but the `HEBREW` property does not, there is no match. Perhaps an `IGNORE_TAAMIM` property is needed as well.

The only way to make the above work is to reimplement some logic:

```js
const result = heb.transliterate("בְּרֵאשִׁ֖יתִי", {
  ADDITIONAL_FEATURES: [
    {
      HEBREW: "בְּרֵאשִׁית",
      FEATURE: "word",
      PASS_THROUGH: true,
      TRANSLITERATION: function (word, hebrew, schema) {
        const taamim = /[\u{0590}-\u{05AF}\u{05BD}\u{05BF}]/u;
        const text = word.text.replace(taamim, "");
        return text.replace(new RegExp(hebrew), "beginning");
      }
    }
  ]
});

console.log(result);
// beginningiy
```

That is almost the expected; I would have expected (maybe) `"beginningî"`.

Perhaps `PASS_THROUGH` should not just map the remaining characters in a tit-for-tat fashion, but rather implement the rest of the rules