### PR TITLE
Letter Order Bug

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,7 +1,7 @@
 import { Cluster } from "havarotjs/cluster";
 import { Syllable } from "havarotjs/syllable";
 import { Word } from "havarotjs/word";
-import { hebChars } from "havarotjs/dist/utils/regularExpressions";
+import { hebChars, clusterSlitGroup } from "havarotjs/dist/utils/regularExpressions";
 import { Schema } from "./schema";
 import { transliterateMap as map } from "./hebCharsTrans";
 
@@ -347,15 +347,14 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
         if (!passThrough) {
           return transliteration(syl, seq.HEBREW, schema);
         }
-        // Refactor this block
-        const newClusters = syl.clusters.map(cluster => {
-            return new Cluster(transliteration(cluster, seq.HEBREW, schema));
-        });
-        syl = new Syllable(newClusters, {
-            isClosed: syl.isClosed,
-            isAccented: syl.isAccented,
-            isFinal: syl.isFinal
-        });
+         const newText = transliteration(syl, seq.HEBREW, schema);
+          const clusterStrings = newText.split(clusterSlitGroup);
+          const newClusters = clusterStrings.map(clusterString => new cluster_1.Cluster(clusterString));
+          syl = new Syllable(newClusters, {
+              isClosed: syl.isClosed,
+              isAccented: syl.isAccented,
+              isFinal: syl.isFinal
+          });
       }
     }
   }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -342,16 +342,19 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
         const transliteration = seq.TRANSLITERATION;
         const passThrough = seq.PASS_THROUGH ?? true;
         if (typeof transliteration === "string") {
-          return replaceAndTransliterate(sylTxt, heb, transliteration, schema);
+            return replaceAndTransliterate(sylTxt, heb, transliteration, schema);
         }
         if (!passThrough) {
-          return transliteration(syl, seq.HEBREW, schema);
+            return transliteration(syl, seq.HEBREW, schema);
         }
-        // this is the only way to make the "// regular syllables" block work
-        syl = new Syllable([new Cluster(transliteration(syl, seq.HEBREW, schema))], {
-          isClosed: syl.isClosed,
-          isAccented: syl.isAccented,
-          isFinal: syl.isFinal
+        // Refactor this block
+        const newClusters = syl.clusters.map(cluster => {
+            return new Cluster(transliteration(cluster, seq.HEBREW, schema));
+        });
+        syl = new Syllable(newClusters, {
+            isClosed: syl.isClosed,
+            isAccented: syl.isAccented,
+            isFinal: syl.isFinal
         });
       }
     }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -342,10 +342,10 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
         const transliteration = seq.TRANSLITERATION;
         const passThrough = seq.PASS_THROUGH ?? true;
         if (typeof transliteration === "string") {
-            return replaceAndTransliterate(sylTxt, heb, transliteration, schema);
+          return replaceAndTransliterate(sylTxt, heb, transliteration, schema);
         }
         if (!passThrough) {
-            return transliteration(syl, seq.HEBREW, schema);
+          return transliteration(syl, seq.HEBREW, schema);
         }
         // Refactor this block
         const newClusters = syl.clusters.map(cluster => {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -347,9 +347,9 @@ export const sylRules = (syl: Syllable, schema: Schema): string => {
         if (!passThrough) {
           return transliteration(syl, seq.HEBREW, schema);
         }
-         const newText = transliteration(syl, seq.HEBREW, schema);
+          const newText = transliteration(syl, seq.HEBREW, schema);
           const clusterStrings = newText.split(clusterSlitGroup);
-          const newClusters = clusterStrings.map(clusterString => new cluster_1.Cluster(clusterString));
+          const newClusters = clusterStrings.map(clusterString => new Cluster(clusterString));
           syl = new Syllable(newClusters, {
               isClosed: syl.isClosed,
               isAccented: syl.isAccented,


### PR DESCRIPTION
Fixes the letter order bug where sometimes syllables lose their form within additional features. E.g. יַלְדָּה would become ylada.

The issue is mentioned here: https://github.com/charlesLoder/hebrew-transliteration/issues/70#issuecomment-1574888637