### PR TITLE
JSS schema

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -129,7 +129,7 @@ const materFeatures = (syl: Syllable, schema: Schema) => {
 
     // tsere
     if (/\u{05B5}/u.test(prevText)) {
-      return replaceWithRegex(noMaterText, /\u{05B5}/u, schema.SEGOL_HE);
+      return replaceWithRegex(noMaterText, /\u{05B5}/u, schema.TSERE_HE);
     }
   }
 

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -4,5 +4,6 @@ import { sblAcademicSpirantization } from "./sblAcademicSpirantization";
 import { sblSimple } from "./sblSimple";
 import { michiganClaremont } from "./michiganClaremont";
 import { romaniote } from "./romaniote";
+import { jss } from "./jss";
 
-export { brillAcademic, brillSimple, sblAcademicSpirantization, sblSimple, michiganClaremont, romaniote };
+export { brillAcademic, brillSimple, sblAcademicSpirantization, sblSimple, michiganClaremont, romaniote, jss };

--- a/src/schemas/jss.ts
+++ b/src/schemas/jss.ts
@@ -1,0 +1,90 @@
+import { Schema } from "../schema";
+
+export const jss: Schema = {
+  VOCAL_SHEVA: "ǝ",
+  HATAF_SEGOL: "ɛ̆",
+  HATAF_PATAH: "ă",
+  HATAF_QAMATS: "å̆",
+  HIRIQ: "i",
+  TSERE: "ē",
+  SEGOL: "ɛ",
+  PATAH: "a",
+  QAMATS: "å̄",
+  HOLAM: "ō",
+  HOLAM_HASER: "ō",
+  QUBUTS: "u",
+  DAGESH: "",
+  DAGESH_CHAZAQ: true,
+  MAQAF: " ",
+  PASEQ: "",
+  SOF_PASUQ: "",
+  QAMATS_QATAN: "å",
+  FURTIVE_PATAH: "a",
+  HIRIQ_YOD: "ī",
+  TSERE_YOD: "ē",
+  SEGOL_YOD: "ɛ",
+  SHUREQ: "ū",
+  HOLAM_VAV: "ō",
+  QAMATS_HE: "å̄",
+  SEGOL_HE: "ɛ",
+  TSERE_HE: "ē",
+  MS_SUFX: "å̄yw",
+  ALEF: "ʾ",
+  BET_DAGESH: "b",
+  BET: "ḇ",
+  GIMEL: "ḡ",
+  GIMEL_DAGESH: "g",
+  DALET: "ḏ",
+  DALET_DAGESH: "d",
+  HE: "h",
+  VAV: "w",
+  ZAYIN: "z",
+  HET: "ḥ",
+  TET: "ṭ",
+  YOD: "y",
+  FINAL_KAF: "ḵ",
+  KAF: "ḵ",
+  KAF_DAGESH: "k",
+  LAMED: "l",
+  FINAL_MEM: "m",
+  MEM: "m",
+  FINAL_NUN: "n",
+  NUN: "n",
+  SAMEKH: "s",
+  AYIN: "ʿ",
+  FINAL_PE: "p̄",
+  PE: "p̄",
+  PE_DAGESH: "p",
+  FINAL_TSADI: "ṣ",
+  TSADI: "ṣ",
+  QOF: "q",
+  RESH: "r",
+  SHIN: "š",
+  SIN: "ś",
+  TAV: "ṯ",
+  TAV_DAGESH: "t",
+  DIVINE_NAME: "yhwh",
+  ADDITIONAL_FEATURES: [
+    {
+      FEATURE: "syllable",
+      // if the syllable contains a qamets qatan character
+      HEBREW: /\u{05C7}/,
+      TRANSLITERATION: (syllable) => {
+        const next = syllable?.next?.value?.text;
+        // if the next syllable includes a hateph qamets, then replace the qamets qatan with a regular qamets
+        if (next && next.includes("\u05B3")) {
+          return syllable.text.replace("\u{05C7}", "\u{05B8}");
+        }
+        return syllable.text;
+      }
+    }
+  ],
+  longVowels: true,
+  qametsQatan: true,
+  sqnmlvy: true,
+  wawShureq: true,
+  article: true,
+  allowNoNiqqud: true,
+  strict: false,
+  holemHaser: "remove"
+};

--- a/test/schemas/jss.test.ts
+++ b/test/schemas/jss.test.ts
@@ -1,0 +1,150 @@
+import { transliterate } from "../../src/index";
+import { jss } from "../../src/schemas/index";
+
+interface Inputs {
+  hebrew: string;
+  transliteration: string;
+}
+
+const schema = jss;
+
+describe("basic tests", () => {
+  test.each`
+    description                    | hebrew                           | transliteration
+    ${"consonants"}                | ${"אבגדהוזחטיכךלמםנןסעפףצץקרשת"} | ${"ʾḇḡḏhwzḥṭyḵḵlmmnnsʿp̄p̄ṣṣqršṯ"}
+    ${"no special cases"}          | ${"רַ֛עַל"}                      | ${"raʿal"}
+    ${"preserve non-Hebrew chars"} | ${"v1. רַ֛עַל"}                  | ${"v1. raʿal"}
+    ${"preserve line breaks"}      | ${"v1.\n רַ֛עַל"}                | ${"v1.\n raʿal"}
+    ${"multiple words and passeq"} | ${"רַ֛עַל ׀ רַ֛עַל"}             | ${"raʿal  raʿal"}
+  `("$description", (inputs: Inputs) => {
+    const { hebrew, transliteration } = inputs;
+    expect(transliterate(hebrew, schema)).toBe(transliteration);
+  });
+});
+
+describe("consonant features", () => {
+  describe("spirantization and ligature tests", () => {
+    test.each`
+      description              | hebrew       | transliteration
+      ${"unspirantized bet"}   | ${"בָּ֣ם"}   | ${"bå̄m"}
+      ${"spirantized bet"}     | ${"אָ֣ב"}    | ${"ʾå̄ḇ"}
+      ${"unspirantized gimel"} | ${"גָּדַ֣ל"} | ${"gå̄ḏal"}
+      ${"spirantized gimel"}   | ${"חָ֣ג"}    | ${"ḥå̄ḡ"}
+      ${"unspirantized dalet"} | ${"דָּ֣ם"}   | ${"då̄m"}
+      ${"spirantized dalet"}   | ${"סַ֣ד"}    | ${"saḏ"}
+      ${"unspirantized kaf"}   | ${"כָּמָ֣ר"} | ${"kå̄må̄r"}
+      ${"spirantized kaf"}     | ${"לֵ֣ךְ"}   | ${"lēḵ"}
+      ${"unspirantized peh"}   | ${"פֹּ֣ה"}   | ${"pōh"}
+      ${"spirantized peh"}     | ${"אֶ֣לֶף"}  | ${"ʾɛlɛp̄"}
+      ${"unspirantized tav"}   | ${"תָּ֣ם"}   | ${"tå̄m"}
+      ${"spirantized tav"}     | ${"מַ֣ת"}    | ${"maṯ"}
+      ${"shin"}                | ${"שֶׁ֣לֶם"}  | ${"šɛlɛm"}
+      ${"sin"}                 | ${"אָ֣רַשׂ"}  | ${"ʾå̄raś"}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration } = inputs;
+      expect(transliterate(hebrew, schema)).toBe(transliteration);
+    });
+  });
+
+  describe("furtive", () => {
+    test.each`
+      description               | hebrew         | transliteration
+      ${"furtive patach, chet"} | ${"נֹ֖חַ"}     | ${"nōaḥ"}
+      ${"furtive patach, ayin"} | ${"רָקִ֖יעַ"}  | ${"rå̄qīaʿ"}
+      ${"furtive patach, he"}   | ${"גָּבֹ֗הַּ"} | ${"gå̄ḇōah"}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration } = inputs;
+      expect(transliterate(hebrew, schema)).toBe(transliteration);
+    });
+  });
+
+  describe("dagesh", () => {
+    test.each`
+      description                          | hebrew            | transliteration
+      ${"dagesh qal beginning of word"}    | ${"בֹּ֔סֶר"}      | ${"bōsɛr"}
+      ${"dagesh qal middle of word"}       | ${"מַסְגֵּ֖ר"}    | ${"masgēr"}
+      ${"dagesh chazaq - not BeGaDKePhaT"} | ${"מִנְּזָר֜"}    | ${"minnǝzå̄r"}
+      ${"dagesh chazaq - BeGaDKePhaT"}     | ${"מַגָּ֖ל"}      | ${"maggå̄l"}
+      ${"doubled shin"}                    | ${"מַשָּׁא"}       | ${"maššå̄ʾ"}
+      ${"doubled tsadi"}                   | ${"לְבִצָּר֔וֹן"} | ${"lǝḇiṣṣå̄rōn"}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration } = inputs;
+      expect(transliterate(hebrew, schema)).toBe(transliteration);
+    });
+  });
+
+  describe("shewa", () => {
+    test.each`
+      description                              | hebrew              | transliteration
+      ${"vocal shewa"}                         | ${"סְלִ֣ק"}         | ${"sǝliq"}
+      ${"silent shewa"}                        | ${"סַלְכָ֣ה"}       | ${"salḵå̄"}
+      ${"final shewa"}                         | ${"כָּ֣ךְ"}         | ${"kå̄ḵ"}
+      ${"two final shewas"}                    | ${"קָטַ֣לְתְּ"}     | ${"qå̄ṭalt"}
+      ${"omitted dagesh chazaq after article"} | ${"הַיְאֹ֗ר"}       | ${"hayǝʾōr"}
+      ${"silent shewa and ligature consonant"} | ${"אַשְׁכְּנַזִּי"} | ${"ʾaškǝnazzī"}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration } = inputs;
+      expect(transliterate(hebrew, schema)).toBe(transliteration);
+    });
+  });
+});
+
+describe("mater features", () => {
+  describe("typical", () => {
+    test.each`
+      description     | hebrew          | transliteration
+      ${"hiriq yod"}  | ${"עִ֔יר"}      | ${"ʿīr"}
+      ${"tsere yod"}  | ${"אֵ֤ין"}      | ${"ʾēn"}
+      ${"seghol yod"} | ${"אֱלֹהֶ֑יךָ"} | ${"ʾɛ̆lōhɛḵå̄"}
+      ${"holem vav"}  | ${"ס֣וֹא"}      | ${"sōʾ"}
+      ${"qamets he"}  | ${"עֵצָ֖ה"}     | ${"ʿēṣå̄"}
+      ${"seghol he"}  | ${"יִקְרֶ֥ה"}   | ${"yiqrɛ"}
+      ${"tsere he"}   | ${"הָאַרְיֵ֔ה"} | ${"hå̄ʾaryē"}
+      ${"shureq"}     | ${"קוּם"}       | ${"qūm"}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration } = inputs;
+      expect(transliterate(hebrew, schema)).toBe(transliteration);
+    });
+  });
+
+  describe("edge cases", () => {
+    test.each`
+      description                                                            | hebrew             | transliteration
+      ${"const yod with hiriq as vowel"}                                     | ${"יַ֣יִן"}        | ${"yayin"}
+      ${"final hiriq yod with maqaf"}                                        | ${"וַֽיְהִי־כֵֽן"} | ${"wayǝhī ḵēn"}
+      ${"hiriq followed by const yod (fake word)"}                           | ${"רִיֵם"}         | ${"riyēm"}
+      ${"consonantal vav with holem as vowel"}                               | ${"עָוֺ֖ן"}        | ${"ʿå̄wōn"}
+      ${"consonantal vav with holem vav as vowel"}                           | ${"עָו֑וֹן"}       | ${"ʿå̄wōn"}
+      ${"consonantal vav with holem, holem vav, and shureq (post biblical)"} | ${"עֲוֹנוֹתֵינוּ"} | ${"ʿăwōnōṯēnū"}
+      ${"initial shureq"}                                                    | ${"וּמִן"}         | ${"ūmin"}
+      ${"bgdkpt letter with mater"}                                          | ${"בִּיטוֹן"}      | ${"bīṭōn"}
+    `("$description", (inputs: Inputs) => {
+      const { hebrew, transliteration } = inputs;
+      expect(transliterate(hebrew, schema)).toBe(transliteration);
+    });
+  });
+});
+
+describe("divine name", () => {
+  test.each`
+    description                    | hebrew           | transliteration
+    ${"by itself"}                 | ${"יְהוָ֥ה"}     | ${"yhwh"}
+    ${"with a maqqef"}             | ${"אֶת־יְהוָ֤ה"} | ${"ʾɛṯ yhwh"}
+    ${"with a preposition"}        | ${"בַּֽיהוָ֔ה"}  | ${"ba-yhwh"}
+    ${"with latin char following"} | ${"יְהוָ֥ה,"}    | ${"yhwh,"}
+  `("$description", (inputs: Inputs) => {
+    const { hebrew, transliteration } = inputs;
+    expect(transliterate(hebrew, schema)).toBe(transliteration);
+  });
+});
+
+describe("qamets qatan", () => {
+  test.each`
+    description            | hebrew           | transliteration
+    ${"standard"}          | ${"כָּל־הָעָ֖ם"} | ${"kål hå̄ʿå̄m"}
+    ${"with hatef qamets"} | ${"נָעֳמִי֙"}    | ${"nå̄ʿå̆mī"}
+  `("$description", (inputs: Inputs) => {
+    const { hebrew, transliteration } = inputs;
+    expect(transliterate(hebrew, schema)).toBe(transliteration);
+  });
+});


### PR DESCRIPTION
This adds the JSS schema discussed in #73.

- There is a separate commit fixing the tsere-he issue. If you prefer I can create a separate MR for it, or you can apply it yourself before the remaining issues with this schema are fixed. It's not urgent for me though, so I wouldn't mind if it's delayed.
- The qamets + hateph qamets issue is tested by an existing test (נָעֳמִי), so I did not add a new one.
- I added tests for hireq/qubuts + meteg, but did not add an implementation. If I understand correctly, the meteg is stripped after stress has been determined, so an `ADDITIONAL_FEATURE` won't work out of the box. I wasn't sure what your preferred way of handling would be.
- The added tests (the last group) may not be outlined correctly for your editor.