### PR TITLE
Remove maqqaf

### DIFF
--- a/src/remove.ts
+++ b/src/remove.ts
@@ -194,6 +194,9 @@ interface RemoveOptions {
   // punctuation //
   /**
    * ־◌
+   *
+   * @description
+   * Unlike other characters, this is replaced with a space instead of being removed.
    */
   MAQAF?: boolean;
   /**
@@ -449,7 +452,9 @@ export const remove = (text: string, options: RemoveOptions = { ...accents, METE
   return keys.reduce((a, c) => {
     const key = removeMap[c as OptionKey] ?? null;
     if (key) {
-      return a.replace(new RegExp(key, "gu"), "");
+      // if it is a MAQAF, replace it with a space
+      const replacement = key === "\u{05BE}" ? " " : "";
+      return a.replace(new RegExp(key, "gu"), replacement);
     }
     return a;
   }, sequenced);

--- a/test/remove.test.ts
+++ b/test/remove.test.ts
@@ -31,3 +31,9 @@ test("remove custom", () => {
   const result = sequence("שָרַ֣י אִשְתְּךָ֔");
   expect(remove(test, { SHIN_DOT: true, SIN_DOT: true })).toBe(result);
 });
+
+test("remove maqqef", () => {
+  const test = "עַֽל־פַּלְגֵ֫י־מָ֥יִם";
+  const result = sequence("עַֽל פַּלְגֵ֫י מָ֥יִם");
+  expect(remove(test, { MAQAF: true })).toBe(result);
+});


### PR DESCRIPTION
See user submitted feedback:

> In the Remove utility, consider replacing maqaf with a space, as opposed to a straight deletion.

That is certainly the best way instead of removing it completely