### PR TITLE
Update how מה־ is handled for tiberian

### DIFF
--- a/src/schemas/tiberian.ts
+++ b/src/schemas/tiberian.ts
@@ -26,7 +26,6 @@ export const tiberian: Schema = {
   SHUREQ: "uː",
   HOLAM_VAV: "oː",
   QAMATS_HE: "ɔː",
-  PATAH_HE: "aː",
   SEGOL_HE: "ɛː",
   TSERE_HE: "eː",
   MS_SUFX: "ɔw",
@@ -371,9 +370,9 @@ export const tiberian: Schema = {
           .filter((c) => !c.isMater)
           .map((c) => c.text)
           .join("")
-          // a patah, tsere, segol, or holam followed by a he without a mappiq is not a mater
+          // a tsere, segol, or holam followed by a he without a mappiq is not a mater
           // but b/c the he is not pronounced, we need to remove the final he
-          .replace(/([\u{05B7}\u{05B5}\u{05B6}\u{05B9}].{0,1})\u{05D4}(?!\u{05BC})/u, "$1");
+          .replace(/([\u{05B5}\u{05B6}\u{05B9}].{0,1})\u{05D4}(?!\u{05BC})/u, "$1");
 
         const hasMaters = syllable.clusters.map((c) => c.isMater).includes(true);
         const lengthMarker = "ː";

--- a/src/schemas/tiberian.ts
+++ b/src/schemas/tiberian.ts
@@ -601,6 +601,13 @@ export const tiberian: Schema = {
         const issachar = "jissɔːˈχɔːɔʀ̟";
         return `${vav}${issachar}`;
       }
+    },
+    {
+      FEATURE: "word",
+      HEBREW: "מַה־",
+      TRANSLITERATION: (word, heb, schema) => {
+        return word.text.replace(heb, schema["MEM"] + schema["PATAH"] + schema["HE"] + schema["MAQAF"]);
+      }
     }
   ],
   allowNoNiqqud: false,

--- a/test/schemas/tiberian.test.ts
+++ b/test/schemas/tiberian.test.ts
@@ -228,7 +228,7 @@ describe("mater features", () => {
       ${"seghol yod"}             | ${"אֱלֹהֶ֑יךָ"} | ${"ʔɛloːˈhɛːχɔː"}
       ${"holem vav"}              | ${"ס֣וֹא"}      | ${"ˈsoː"}
       ${"qamets he"}              | ${"עֵצָ֖ה"}     | ${"ʕeːˈsˁɔː"}
-      ${"patah he"}               | ${"מַה־"}       | ${"maː-"}
+      ${"patah he"}               | ${"מַה־"}       | ${"mah-"}
       ${"seghol he"}              | ${"יִקְרֶ֥ה"}   | ${"jiq̟ˈʀ̟ɛː"}
       ${"seghol he (unaccented)"} | ${"עֹ֥שֶׂה"}    | ${"ˈʕoːsɛː"}
       ${"tsere he"}               | ${"הָאַרְיֵ֔ה"} | ${"hɔːʔaʀ̟ˈjeː"}


### PR DESCRIPTION
Closes #172 by focusing on only fixing מה־ for tiberian