### PR TITLE
Issue 178/incorrect output

### DIFF
--- a/src/schemas/tiberian.ts
+++ b/src/schemas/tiberian.ts
@@ -237,14 +237,14 @@ export const tiberian: Schema = {
     },
     {
       FEATURE: "cluster",
-      HEBREW: "\u{05D0}(?![\u{05B1}-\u{05BB}\u{05C7}])",
-      TRANSLITERATION: (cluster) => {
+      HEBREW: /\u{05D0}(?![\u{05B1}-\u{05BB}\u{05C7}])/u,
+      TRANSLITERATION: (cluster, heb) => {
         const next = cluster.next?.value;
-        if (next?.isShureq) {
+        if (next?.isShureq || !cluster?.prev) {
           return cluster.text;
         }
 
-        return "";
+        return cluster.text.replace(heb, "");
       }
     },
     {

--- a/test/schemas/tiberian.test.ts
+++ b/test/schemas/tiberian.test.ts
@@ -146,10 +146,11 @@ describe("consonant features", () => {
 
   describe("aleph", () => {
     test.each`
-      description            | hebrew             | transliteration
-      ${"regular aleph"}     | ${"לְאַבֵּ֔ד"}     | ${"laʔabˈbeːeð"}
-      ${"quiesced aleph"}    | ${"בְּרֵאשִׁ֖ית"}  | ${"baʀ̟eːˈʃiːiθ"}
-      ${"aleph with shureq"} | ${"הִשִּׁיא֛וּךָ"} | ${"hiʃʃiːˈʔuːχɔː"}
+      description                                                                     | hebrew             | transliteration
+      ${"regular aleph"}                                                              | ${"לְאַבֵּ֔ד"}     | ${"laʔabˈbeːeð"}
+      ${"quiesced aleph"}                                                             | ${"בְּרֵאשִׁ֖ית"}  | ${"baʀ̟eːˈʃiːiθ"}
+      ${"aleph with shureq"}                                                          | ${"הִשִּׁיא֛וּךָ"} | ${"hiʃʃiːˈʔuːχɔː"}
+      ${"aleph which does not have a hebrew vowel by the time the cluster rule runs"} | ${"אַרְנֹ֗ן"}      | ${"ʔɑrˁˈnoːon"}
     `("$description", (inputs: Inputs) => {
       const { hebrew, transliteration } = inputs;
       expect(transliterate(hebrew, schema)).toBe(transliteration);

--- a/test/schemas/tiberian.test.ts
+++ b/test/schemas/tiberian.test.ts
@@ -19,7 +19,7 @@ describe("basic tests", () => {
         allowNoNiqqud: true,
         STRESS_MARKER: undefined
       })
-    ).toBe("vʁðhvzħtˁjχχlmmnnsʕffsˁsˁq̟ʀ̟ʃθ");
+    ).toBe("ʔvʁðhvzħtˁjχχlmmnnsʕffsˁsˁq̟ʀ̟ʃθ");
   });
 
   test.each`


### PR DESCRIPTION
Closes #178 

With how the rule was originally written, when the cluster text would come in, because it had been processed by previous rules, instead of `אַרְ` it was `אɑrˁְ`.

It would match as if it were a quiesced aleph, and then get replaced by an empty string.

This rule handles it more robustly